### PR TITLE
updated demo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ can be found [here](https://github.com/OHNLP/MedTagger/tree/master/src/main/reso
 what to do/extract, and this directory is expected as input for the RULEDIR parameter 
 
 # Installation and Use
-#### Live demo for COVID-19 ruleset: http://167.114.144.164/
+#### Live demo for COVID-19 ruleset: https://ohnlp.github.io/ohnlptk/
 #### Video demo: https://vimeo.com/392331446
 1. Download the latest release from https://github.com/OHNLP/MedTagger/releases
 2. Extract the zip file


### PR DESCRIPTION
replacing the old URL to https://ohnlp.github.io/ohnlptk/